### PR TITLE
Add minimal 4‑bus example simulation

### DIFF
--- a/examples/minimal_grid_attack/README.md
+++ b/examples/minimal_grid_attack/README.md
@@ -1,0 +1,23 @@
+# Minimal Grid Attack Example
+
+This directory contains a stripped down co-simulation setup showing how to run
+ANALYSE with only a small pandapower grid and a single reinforcement learning
+agent.  It reuses the `four_bus` example network shipped with MIDAS and omits
+any ICT components.
+
+* `four_bus_der.yml` – MIDAS scenario describing the four bus system with two
+  PV/CHP units.  Loads and weather vary over time so the grid is not static.
+* `minimal_grid_attack.yml` – palaestrAI run file training a simple PPO agent
+  that manipulates the reactive power of one PV unit.  The reward is the
+  voltage deviation on all buses.
+* `minimal_scenario.py` – script to execute the scenario without RL to verify
+  that it runs standalone.
+
+Run the RL experiment with:
+
+```bash
+palaestrai experiment-start examples/minimal_grid_attack/minimal_grid_attack.yml
+```
+
+After the run you can inspect `minimal_arl.hdf5` for the agent's actions and
+`minimal_fourbus.hdf5` for the raw simulation outputs.

--- a/examples/minimal_grid_attack/four_bus_der.yml
+++ b/examples/minimal_grid_attack/four_bus_der.yml
@@ -1,0 +1,59 @@
+#######################################################################
+# Minimal 4-Bus Scenario
+#
+# This YAML file defines a small MIDAS power grid scenario.  It is largely
+# identical to MIDAS' built in ``four_bus_der`` example but we include it here
+# so it can be referenced from the experiment configuration in this repository.
+#
+# The scenario uses:
+#   * the ``simple_four_bus_system`` pandapower network
+#   * static load profiles via ``sndata``
+#   * a single weather provider and two PV + CHP units
+#
+# The simulation runs with a 15 minute step size for one day.
+#######################################################################
+four_bus:
+  name: four_bus
+  parent:
+  modules: [store, powergrid, sndata]
+  step_size: 15*60
+  start_date: 2009-01-01 00:00:00+0100
+  end: 1*24*60*60
+  silent: true
+  # DataStore collects all simulation results in an HDF5 file so they can be
+  # inspected afterwards with e.g. pandas.  The name does not matter, but make
+  # it unique for this demo scenario.
+  store_params:
+    filename: minimal_fourbus.hdf5
+  powergrid_params:
+    four_bus:
+      gridfile: simple_four_bus_system
+  sndata_params:
+    four_bus:
+      active_mapping:
+        2: [[Land_0, 0.75]]
+        3: [[Land_3, 0.425]]
+#######################################################################
+# Four Bus System with DER
+#######################################################################
+four_bus_der:
+  name: four_bus_der
+  parent: four_bus
+  modules: [weather, der]
+  weather_params:
+    bremen:
+      weather_mapping:
+        WeatherCurrent:
+          - interpolate: True
+            randomize: True
+  der_params:
+    four_bus_pv:
+      grid_name: four_bus
+      mapping:
+        2: [[PV, 0.00725], [CHP, 0.014]]
+        3: [[PV, 0.00103], [CHP, 0.014]]
+      weather_provider_mapping:
+        PV: [bremen, 0]
+        CHP: [bremen, 0]
+
+# End of scenario definition

--- a/examples/minimal_grid_attack/minimal_grid_attack.yml
+++ b/examples/minimal_grid_attack/minimal_grid_attack.yml
@@ -1,0 +1,74 @@
+uid: "Minimal Powergrid Run"
+seed: 0
+version: 3.4.1
+schedule:
+  - training_phase:
+      environments:
+        - environment:
+            uid: minimal_env
+            name: palaestrai_mosaik:MosaikEnvironment
+            params:  # Mosaik Environment Parameters
+              module: midas.tools.palaestrai:Descriptor
+              description_func: describe
+              instance_func: get_world
+              arl_sync_freq: &step_size 900  # 15 min steps
+              end: &end 1*24*60*60         # one day
+              silence_missing_input_connections_warning: true
+              params:  # Midas Parameters
+                name: four_bus_der
+                config:
+                  - examples/minimal_grid_attack/four_bus_der.yml
+                end: *end
+                step_size: *step_size
+                mosaik_params: {addr: [127.0.0.1, 56789]}
+                store_params: {filename: minimal_arl.hdf5}
+          reward:
+            # Use a simple voltage deviation based reward. Positive values mean
+            # higher voltages, negative values lower voltages.
+            name: midas_palaestrai.rewards:VoltageBandDeviationReward
+            params: {}
+      agents:
+        - name: simple_attacker
+          brain:
+            # PPO supports discrete or continuous action spaces. Our actuator is
+            # continuous (reactive power), therefore we stick with PPO's default
+            # continuous settings.
+            name: harl.ppo.brain:PPOBrain
+            params:
+              fc_dims: [64, 64]
+              timesteps_per_batch: 4
+              n_updates_per_iteration: 4
+              max_timesteps_per_episode: 96
+          muscle:
+            name: harl.ppo.muscle:PPOMuscle
+            params: {}
+          objective:
+            name: midas.tools.palaestrai.objectives:PowerGridAttackerObjective
+            params: {is_defender: false}
+          sensors:
+            # Observe all bus voltages of the 4-bus grid
+            - analyse.Powergrid-0.0-bus-1.vm_pu
+            - analyse.Powergrid-0.0-bus-2.vm_pu
+            - analyse.Powergrid-0.0-bus-3.vm_pu
+            - analyse.Powergrid-0.0-bus-4.vm_pu
+          actuators:
+            # Control the reactive power output of the first PV unit
+            - analyse.Pysimmods-0.Photovoltaic-0.q_set_mvar
+      simulation:
+        name: palaestrai.simulation:VanillaSimController
+        conditions:
+          - name: palaestrai.simulation:VanillaSimControllerTerminationCondition
+            params: {}
+      phase_config:
+        mode: train
+        worker: 1
+        episodes: 2
+  - test_phase:
+      phase_config:
+        mode: test
+        worker: 1
+        episodes: 1
+run_config:
+  condition:
+    name: palaestrai.experiment:VanillaRunGovernorTerminationCondition
+    params: {}

--- a/examples/minimal_grid_attack/minimal_scenario.py
+++ b/examples/minimal_grid_attack/minimal_scenario.py
@@ -1,0 +1,25 @@
+"""Standalone MIDAS scenario runner for the minimal 4-bus example.
+
+Running this script will launch the power system co-simulation without
+any reinforcement learning agent attached.  It can be used to quickly
+check that the scenario itself executes and produces reasonable power
+flow results.
+"""
+import os
+import midas.api as mia
+
+
+def main():
+    # Resolve the YAML path relative to this script
+    scenario_path = os.path.join(
+        os.path.dirname(__file__), "four_bus_der.yml"
+    )
+    # Run the scenario for one simulated day
+    mia.run("four_bus_der", {"end": 24 * 60 * 60}, scenario_path)
+    # After completion the ``minimal_fourbus.hdf5`` file can be inspected with
+    # your favourite pandas or HDF5 viewer to check bus voltages and generator
+    # outputs over time.
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a minimal 4‑bus MIDAS scenario and experiment configuration
- provide a small helper script and README on how to run it

## Testing
- `python3 -m py_compile examples/minimal_grid_attack/minimal_scenario.py`

------
https://chatgpt.com/codex/tasks/task_e_686f9120a70c83328d876acf2a01869d