### PR TITLE
Fix simulation controller name for PalaestrAI >=3.5

### DIFF
--- a/examples/minimal_grid_attack/minimal_grid_attack.yml
+++ b/examples/minimal_grid_attack/minimal_grid_attack.yml
@@ -55,7 +55,8 @@ schedule:
             # Control the reactive power output of the first PV unit
             - analyse.Pysimmods-0.Photovoltaic-0.q_set_mvar
       simulation:
-        name: palaestrai.simulation:VanillaSimController
+        # PalaestrAI >=3.5 expects the longer class name
+        name: palaestrai.simulation:VanillaSimulationController
         conditions:
           - name: palaestrai.simulation:VanillaSimControllerTerminationCondition
             params: {}

--- a/src/analyse/experiments/ict_attack_experiment.yml
+++ b/src/analyse/experiments/ict_attack_experiment.yml
@@ -104,7 +104,8 @@ schedule:
             # - analyse.QMarket-0.QMarketModel_0.agent_bid_6
             # - analyse.QMarket-0.QMarketModel_0.agent_bid_7
       simulation:
-        name: palaestrai.simulation:VanillaSimController
+        # Adjusted for palaestrAI >=3.5
+        name: palaestrai.simulation:VanillaSimulationController
         conditions:
           - name: palaestrai.simulation:VanillaSimControllerTerminationCondition
             params: {}

--- a/src/analyse/experiments/market_attack_experiment.yml
+++ b/src/analyse/experiments/market_attack_experiment.yml
@@ -104,7 +104,8 @@ schedule:
             # - analyse.QMarket-0.QMarketModel_0.agent_bid_6
             # - analyse.QMarket-0.QMarketModel_0.agent_bid_7
       simulation:
-        name: palaestrai.simulation:VanillaSimController
+        # Adjusted for palaestrAI >=3.5
+        name: palaestrai.simulation:VanillaSimulationController
         conditions:
           - name: palaestrai.simulation:VanillaSimControllerTerminationCondition
             params: {}

--- a/src/analyse/experiments/powergrid_attack_experiment.yml
+++ b/src/analyse/experiments/powergrid_attack_experiment.yml
@@ -96,7 +96,8 @@ schedule:
             - analyse.Pysimmods-0.Photovoltaic-7.p_set_mw
             - analyse.Pysimmods-0.Photovoltaic-7.q_set_mvar
       simulation:
-        name: palaestrai.simulation:VanillaSimController
+        # Adjusted for palaestrAI >=3.5
+        name: palaestrai.simulation:VanillaSimulationController
         conditions:
           - name: palaestrai.simulation:VanillaSimControllerTerminationCondition
             params: {}


### PR DESCRIPTION
## Summary
- update example and experiment configs to use `VanillaSimulationController`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6878d4aa2ef08332a9acc1ac36968ffd