### PR TITLE
Update Mosaik environment timeout key

### DIFF
--- a/examples/minimal_grid_attack/minimal_grid_attack.yml
+++ b/examples/minimal_grid_attack/minimal_grid_attack.yml
@@ -14,7 +14,7 @@ schedule:
               arl_sync_freq: &step_size 900  # 15 min steps
               end: &end 1*24*60*60         # one day
               silence_missing_input_connections_warning: true
-              timeout: 600
+              simulation_timeout: 600
               params:  # Midas Parameters
                 name: four_bus_der
                 config:


### PR DESCRIPTION
## Summary
- fix configuration field name for MosaikEnvironment timeout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f637c24a48332929470a0416c627f